### PR TITLE
Not filter hourly data

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -556,4 +556,4 @@ class TrendReq(object):
                 time.sleep(sleep)
 
         # return the dataframe with results from our timeframe
-        return df.loc[initial_start_date:end_date]
+        return df


### PR DESCRIPTION
It will be filtered and _scaled_ in superapi

https://app.shortcut.com/supermetrics/story/88764/gt-something-went-wrong-with-interest-by-hour-rt