### PR TITLE
Fix cookie retrieval URL due to 301 error

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -67,7 +67,7 @@ class TrendReq(object):
             if "proxies" in self.requests_args:
                 try:
                     return dict(filter(lambda i: i[0] == 'NID', requests.get(
-                        'https://trends.google.com/?geo={geo}'.format(
+                        'https://trends.google.com/home?geo={geo}'.format(
                             geo=self.hl[-2:]),
                         timeout=self.timeout,
                         **self.requests_args
@@ -81,7 +81,7 @@ class TrendReq(object):
                     proxy = ''
                 try:
                     return dict(filter(lambda i: i[0] == 'NID', requests.get(
-                        'https://trends.google.com/?geo={geo}'.format(
+                        'https://trends.google.com/home?geo={geo}'.format(
                             geo=self.hl[-2:]),
                         timeout=self.timeout,
                         proxies=proxy,


### PR DESCRIPTION
It started to fail with 429. While uncouncious testing different approaches to make it work I started to add headers that are present in the request from UI. Cookie has helped. After it I went debugging coockie retrieval and saw that `https://trends.google.com/` responses with 301. So, I took the URL that browser redirects after you go to https://trends.google.com/ it's https://trends.google.com/home at the moment